### PR TITLE
Fix mixed content warning

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
      An explanation of this licence in other languages can be found at
     
-           http://creativecommons.org/licenses/by-nc-sa/2.0/fr
+           https://creativecommons.org/licenses/by-nc-sa/2.0/fr
 
 ...............................................................................
 
@@ -317,4 +317,4 @@
    telles qu'elles sont disponibles sur son site Internet ou sur simple
    demande.
 
-   Creative Commons peut être contacté à http://creativecommons.org/.
+   Creative Commons peut être contacté à https://creativecommons.org/.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ license. For the details see the file [`LICENSE`](LICENSE).
 
 [1]: http://gallium.inria.fr/~remy/camlunix/ 
 
-Project home page : http://ocaml.github.io/ocamlunix  
+Project home page : https://ocaml.github.io/ocamlunix
 Contact & typos : `Daniel Bünzli daniel.buenzl i@erratique.ch`
 
 

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -3,7 +3,7 @@
  
   All rights reserved. Distributed under a creative commons
   attribution-non-commercial-share alike 2.0 France license.
-  http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+  https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
  ----------------------------------------------------------------------------*)
 
 open Ocamlbuild_plugin;;

--- a/src/files.tex
+++ b/src/files.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Richard Paradies, reworked by Daniel C. Buenzli
 %------------------------------------------------------------------------------

--- a/src/front.tex
+++ b/src/front.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Daniel C. Buenzli
 %------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ Rights reserved.
 \ifhtmlelse
     {Consult the \href{LICENSE}{license.}  \href{\licenseURL}%
       {\imgsrc[alt="CreativeCommons License" class="ccimage"]%
-        {http://i.creativecommons.org/l/by-nc-sa/2.0/fr/80x15.png}}
+        {https://i.creativecommons.org/l/by-nc-sa/2.0/fr/80x15.png}}
     }
     {Distributed under the Creative Commons Attribution~--~Non 
      commercial~--~Share alike 2.0 France license. See
@@ -53,7 +53,7 @@ Available as a \ahref{ocamlunix.html}{monolithic file},
 \ahref{index.html}{by chapters}, and in \ahref{ocamlunix.pdf}{PDF}
 --- 
 % \ahref{ocamlunix-!!VERSION!!.tbz}{sources}, 
-git \href{http://github.com/ocaml/ocamlunix/}{repository}.}
+git \href{https://github.com/ocaml/ocamlunix/}{repository}.}
 
 \vfill
 \begin{abstract}

--- a/src/general.tex
+++ b/src/general.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Eliot Handelman (eliot@colba.net)
 %------------------------------------------------------------------------------

--- a/src/intro.tex
+++ b/src/intro.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Daniel C. Buenzli
 %------------------------------------------------------------------------------

--- a/src/more.tex
+++ b/src/more.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by
 %------------------------------------------------------------------------------

--- a/src/ocamlunix.tex
+++ b/src/ocamlunix.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %------------------------------------------------------------------------------
 
 \documentclass[twoside,openright,a4paper,11pt]{memoir}
@@ -26,7 +26,7 @@
 \newcommand{\mytitle}{Unix system programming in OCaml}
 \newcommand{\myauthors}{Xavier Leroy and Didier Rémy}
 \newcommand{\mykeywords}{Software,OCaml,Unix,Programming,System}
-\newcommand{\licenseURL}{http://creativecommons.org/licenses/by-nc-sa/2.0/fr/}
+\newcommand{\licenseURL}{https://creativecommons.org/licenses/by-nc-sa/2.0/fr/}
 
 \usepackage{hyperref}
 \usepackage{prelude}   % Differentiation between html and pdf output

--- a/src/pipes.tex
+++ b/src/pipes.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Daniel C. Buenzli
 %------------------------------------------------------------------------------

--- a/src/prelude.hva
+++ b/src/prelude.hva
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %------------------------------------------------------------------------------
 
 % Definitions for HTML output.

--- a/src/prelude.sty
+++ b/src/prelude.sty
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %------------------------------------------------------------------------------
 
 % Definitions for PDF output.

--- a/src/processes.tex
+++ b/src/processes.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Mark Wong-VanHaren
 %------------------------------------------------------------------------------

--- a/src/references.tex
+++ b/src/references.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Daniel C. Buenzli
 %------------------------------------------------------------------------------

--- a/src/signals.tex
+++ b/src/signals.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Thaddeus Meyer
 %------------------------------------------------------------------------------

--- a/src/sockets.tex
+++ b/src/sockets.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Till Varoquaux, Priya Hattiangdi and Prashanth Mundkur
 % Reworked by Daniel C. Buenzli

--- a/src/threads.tex
+++ b/src/threads.tex
@@ -3,7 +3,7 @@
 %
 % All rights reserved. Distributed under a creative commons
 % attribution-non-commercial-share alike 2.0 France license.
-% http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+% https://creativecommons.org/licenses/by-nc-sa/2.0/fr/
 %
 % Translation by Eric Cooper <ecc@cmu.edu>
 %------------------------------------------------------------------------------


### PR DESCRIPTION
When visiting https://ocaml.github.io/ocamlunix/, FireFox gives a warning: “Parts of this page are not secure (such as images).” This is due to the embedded Creative Commons banner, which is loaded from an HTTP URL. This switches it to HTTPS.

While here, switch all Creative Commons and GitHub URLs to HTTPS, because why not.