### PR TITLE
Fix link to RFC reference site

### DIFF
--- a/src/sockets.tex
+++ b/src/sockets.tex
@@ -1028,7 +1028,7 @@ adopt the described protocol.\footnote{\textsc{rfc}s are available
   via anonymous \textsc{ftp} on numerous sites. In France:
   \href{ftp://ftp.inria.fr}{\texttt{ftp.inria.fr}}, in the directory
   \href{ftp://ftp.inria.fr/pub/rfc/}{\texttt{rfc}}. The reference site
-  is \url{http://www.faqs.org/rfcs/}. }
+  is \url{https://ietf.org/standards/rfcs/}. }
 
 
 \subsection*{\quotes{Binary} protocols}


### PR DESCRIPTION
It may be debatable which is the real "reference site" for RFCs. However, it is certainly not a third-party site like faqs.org. Replacing the link with a link to the IETF, the organization that creates, authors and maintains all RFCs.